### PR TITLE
fix: Prevent drainage by replay attacks by locking contract on exploit

### DIFF
--- a/contracts/src/VerifierContract.sol
+++ b/contracts/src/VerifierContract.sol
@@ -2,19 +2,21 @@
 pragma solidity ^0.8.0;
 
 import {IRiscZeroVerifier} from "../lib/risc0-ethereum/contracts/src/IRiscZeroVerifier.sol";
+import {Ownable} from "../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 
 /// @notice Interface for the ImageID contract.
 interface IImageID {
     function ZKPOEX_GUEST_ID() external view returns (bytes32);
 }
 
-contract VerifierContract {
+contract VerifierContract is Ownable {
     /// @notice Image ID of the only zkVM binary to accept verification from.
     bytes32 public imageId;
     /// @notice Reward amount (in wei) for a valid exploit.
     uint256 public constant REWARD_IN_ETH = 1000;
+    /// @notice Boolean indicating if contract is locked for exploit proof verification.
+    bool public exploit_proof_verification_locked = false;
 
-    address public owner;
     IRiscZeroVerifier public immutable risc0_verifier_contract;
 
     // The stored hashes are computed as keccak256(abi.encodePacked(input))
@@ -28,12 +30,32 @@ contract VerifierContract {
         bytes32 _program_spec_hash,
         bytes32 _context_state_hash,
         address _image_id_contract
-    ) {
+    ) Ownable(msg.sender) {
         risc0_verifier_contract = IRiscZeroVerifier(_risc0_verifier_contract);
-        owner = msg.sender;
         program_spec_hash = _program_spec_hash;
         context_state_hash = _context_state_hash;
         imageId = IImageID(_image_id_contract).ZKPOEX_GUEST_ID();
+    }
+
+    /// @notice Returns a boolean indicating if the contract is locked for exploit proof verification.
+    /// @dev This function is used to check if the contract is locked.
+    /// @return Boolean indicating if the contract is locked.
+    function isLocked() external view returns (bool) {
+        return exploit_proof_verification_locked;
+    }
+
+    /// @notice Locks the contract to prevent further exploit proof verification.
+    /// @dev Only callable by the contract owner.
+    /// @dev This function is used to lock the contract from further exploit proof verification.
+    function lock() public onlyOwner {
+        exploit_proof_verification_locked = true;
+    }
+
+    /// @notice Unlocks the contract to allow further exploit proof verification.
+    /// @dev Only callable by the contract owner.
+    /// @dev This function is used to unlock the contract for further exploit proof verification.
+    function unlock() public onlyOwner {
+        exploit_proof_verification_locked = false;
     }
 
     /// @notice Updates the target contract and the expected hashes.
@@ -41,9 +63,8 @@ contract VerifierContract {
     function updateVerifierFields(
         bytes32 _program_spec_hash,
         bytes32 _context_state_hash
-    ) external {
+    ) public onlyOwner {
         // TODO: Add some kind of delay to avoid owners from front-running provers.
-        require(msg.sender == owner, "Only owner");
         program_spec_hash = _program_spec_hash;
         context_state_hash = _context_state_hash;
     }
@@ -56,6 +77,12 @@ contract VerifierContract {
         bytes calldata seal,
         bytes calldata journal
     ) public payable {
+        // Check if contract is locked for exploit proof verification.
+        require(
+            !exploit_proof_verification_locked,
+            "Contract is locked for exploit proof verification"
+        );
+        
         risc0_verifier_contract.verify(seal, imageId, sha256(journal));
 
         (
@@ -82,6 +109,9 @@ contract VerifierContract {
         // Emit event
         emit ExploitFound(beneficiary, address(this));
         require(payable(beneficiary).send(REWARD_IN_ETH), "Transfer failed");
+
+        // Lock the contract to prevent further exploit proof verification until it is unlocked.
+        exploit_proof_verification_locked = true;
     }
 
     receive() external payable {}


### PR DESCRIPTION
- Add `Ownable` for easier management of owner in `VerifierContract`
- Add `lock()` and `unlock()` methods, only managed by `owner`
- After successful verification of an exploit, lock the contract until the smart contract owner publishes a new spec and/or unlocks the contract

Closes #4 