### PR TITLE
feat: Add support for H256 instead of treating everything as U256

### DIFF
--- a/evm-runner/Cargo.toml
+++ b/evm-runner/Cargo.toml
@@ -13,4 +13,5 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 hpke = { version = "0.12.0" }
 rand = { version = "0.8.5" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ethabi = { version = "18.0.0" }


### PR DESCRIPTION
<!-- # Feature - Name your Feature --> 
<!-- # Bugfix -  Name your Bug --> 
<!-- # Enhancement -  Name your Enhancement --> 
## Description
<!--- Describe your changes in detail -->
Add support for both `U256` and `H256` via a new enum called `Word256`.
Until now, only `U256` values were handled, this means that whenever state was obtained from storage we were interpreting it as a `U256` when there are times we may not want to do so (though for comparison it may suffice, it is not conceptually correct)

Closes #3 

## Issues
<!--- Link to issue if needed via "Closes {{issue}}" -->

## Tests
<!--- Did you make tests? Why not? -->

